### PR TITLE
add space/backslash at end of output lines

### DIFF
--- a/android-blob-utility.c
+++ b/android-blob-utility.c
@@ -244,7 +244,7 @@ void get_lib_from_system_dump(char *system_check) {
         sprintf(system_dump_path_to_blob, "%s%s%s", system_dump_root, blob_directories[i],
                 system_check);
         if (!access(system_dump_path_to_blob, F_OK)) {
-            printf("vendor/%s/%s/proprietary%s%s:system%s%s\n", system_vendor, system_device,
+            printf("vendor/%s/%s/proprietary%s%s:system%s%s \\\n", system_vendor, system_device,
                     blob_directories[i], system_check, blob_directories[i], system_check);
             dot_so_finder(system_dump_path_to_blob);
             found_hit = true;


### PR DESCRIPTION
Really love the utility.
I was finding myself having to add the space and backslash manually to drop the output into makefiles;
then I thought, it's a program, why not just make it print that way to save time?
