### PR TITLE
Improvements to Android Blob Utilities

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,16 +14,13 @@ ifeq ($(VARIABLES_PROVIDED), true)
 	CFLAGS += -DVARIABLES_PROVIDED
 endif
 
-OBJECTS = android-blob-utility.o
-SOURCE = android-blob-utility.c
 MODULE = android-blob-utility
 
 
-android-blob-utility: $(OBJECTS)
-	$(CC) $(CFLAGS) $(OBJECTS) -o $(MODULE) $(LDFLAGS)
+all: $(MODULE)
 
-all: android-blob-utility
+$(MODULE): $(MODULE).h
 
 clean:
-	-rm -f $(OBJECTS) $(MODULE)
+	-rm -f $(MODULE)
 

--- a/android-blob-utility.c
+++ b/android-blob-utility.c
@@ -419,6 +419,10 @@ void dot_so_finder(char *filename) {
     struct stat file_stat;
 
     file_fd = open(filename, O_RDONLY);
+    if (file_fd == -1) {
+        printf("File %s not found, exiting!\n", filename);
+        exit(1);
+    }
 
     fstat(file_fd, &file_stat);
 

--- a/android-blob-utility.c
+++ b/android-blob-utility.c
@@ -502,8 +502,8 @@ void remove_unwanted_characters(char *input) {
     if (p)
         *p = '\0';
 
-    p = strchr(input, '\0'); /* remove final slash in /home/android/dump/ */
-    if (p && *(p - 1) == '/')
+    p = input + strlen(input); /* remove final slash in /home/android/dump/ */
+    if (*(p - 1) == '/')
         *(p - 1) = '\0';
 }
 

--- a/android-blob-utility.h
+++ b/android-blob-utility.h
@@ -52,6 +52,8 @@ const char *blob_directories[] = {
     "/lib/hw/",
     "/lib64/",
     "/lib/",
+    "/usr/lib/",
+    "/usr/lib/alsa-lib/",
     "/bin/",
     NULL
 };


### PR DESCRIPTION
Hi JackpotClavin,

I've used your blob utility and found it very useful.

I've made a few changes that helped me use it. I would be glad If you would like to include them in your repository. Here is a brief description. Cosmetic changes are really only cosmetic and not really useful.

a63311b Simplify Makefile
  Mostly cosmetic. However, it adds a dependency on
  android-blob-utility.h to recompile also when the .h is
  changed.

42d5a0c Add some directories to look for libs
  Useful for my setup. Some libraries are in different
  directories.

771dc45 Do not crash on non existing file
  This is cleaner to exit with a message instead of
  crashing.

ddbfa92 Use build.prop and provided path as defaults
  Since API level, vendor and board name are written
  in build.prop, we can use build.prop to provide a
  default value. If the input is empty, use the default
  value, otherwise you can change it.

bbbd1bf Make control output on stderr
  This makes using the program easier: prompts and
  messages go to stderr, so that the stdout gets only
  the list of files that goes into .mk

d90d22a Nicer way to remove final slash
   Cosmetic

003d0d7 Do not exit on non-existing file
   Cosmetic

```
 Thanks once again,

       SurJector
```
